### PR TITLE
When we edit the note and erase then label, the note should be not edited as blank. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,6 @@ TODO
     - Still a problem when we try to overwright the remaining redo stuff by our new input. I can't succeed to truncate the history properly. Maybe because of shady Angular mechanism.
     If I could have some ***feedback*** here, it would be awesome. I have first implemented the logic in the todolist component, but I remembered that the logic is preferred as a service.
  
+ - Branch "bug-fix-user-should-not-edit-an-item-to-null" : When we edit the note and erase then label, the note should be not edited as blank. Now, when the user reproduce this behaviour,
+ modification is passed off. 
+ 

--- a/src/app/todo-item/todo-item.component.ts
+++ b/src/app/todo-item/todo-item.component.ts
@@ -30,7 +30,11 @@ export class TodoItemComponent implements OnInit {
   }
 
   set label(lab: string) {
-    this.todoService.setItemsLabel(lab, this.item);
+    if (lab.length !== 0) {
+      this.todoService.setItemsLabel(lab, this.item);
+    } else {
+      this.todoService.setItemsLabel(this.label, this.item);
+    }
   }
 
   get isDone(): boolean {


### PR DESCRIPTION
Now, when the user reproduce this behaviour, modification is passed off.